### PR TITLE
switch to cloudflare workers

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,37 @@
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    
+    // Try to serve the static asset
+    try {
+      const asset = await env.ASSETS.fetch(request);
+      if (asset.status !== 404) {
+        return asset;
+      }
+    } catch (error) {
+      console.error('Asset fetch error:', error);
+    }
+    
+    // If no asset found and it's not an API route, serve index.html for SPA routing
+    if (!url.pathname.startsWith('/api/') && !url.pathname.includes('.')) {
+      try {
+        const indexRequest = new Request(new URL('/index.html', url.origin));
+        const indexAsset = await env.ASSETS.fetch(indexRequest);
+        if (indexAsset.status !== 404) {
+          return new Response(indexAsset.body, {
+            status: 200,
+            headers: {
+              ...Object.fromEntries(indexAsset.headers),
+              'Content-Type': 'text/html',
+            },
+          });
+        }
+      } catch (error) {
+        console.error('Index.html fetch error:', error);
+      }
+    }
+    
+    // Return 404 for everything else
+    return new Response('Not Found', { status: 404 });
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "jbrio-net"
+compatibility_date = "2025-08-07"
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+not_found_handling = "single-page-application"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "jbrio-net"
+main = "src/worker.js"
 compatibility_date = "2025-08-07"
 
 [assets]
 directory = "./dist"
-not_found_handling = "single-page-application"
+binding = "ASSETS"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,5 +3,4 @@ compatibility_date = "2025-08-07"
 
 [assets]
 directory = "./dist"
-binding = "ASSETS"
 not_found_handling = "single-page-application"


### PR DESCRIPTION
Configure static site deployment to Workers with:
- Basic compatibility settings for 2025
- Asset directory pointing to ./dist
- Single page application routing support

This prepares the site for migration from Cloudflare Pages to Workers Builds with automatic GitHub integration.

🤖 Generated with [Claude Code](https://claude.ai/code)